### PR TITLE
Refine landing page hero spacing

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -63,7 +63,7 @@
     </div>
 
     <sc-if value="{{ showSchematic }}" hint-placeholder-val="{{ true }}">
-      <div class="rise d2" style="max-width:360px;width:100%;margin-left:auto">
+      <div class="rise d2" style="max-width:360px;width:100%;margin-left:auto;margin-right:28px">
         <x-import component-from-global-scope="DesignSystem_ee75f1.PhotoFrame" src="assets/repin-self-portrait.png" alt="伊利亚·列宾自画像，1878" ratio="789/1000" object-position="50% 22%" caption="Ilya Repin · 自画像 1878" hint-size="100%,440px"></x-import>
         <p class="latin" style="color:var(--muted);font-size:14.5px;line-height:1.6;margin:14px 0 0">Ilya Repin, <span style="font-style:normal;font-family:var(--font-serif);font-size:13.5px">自画像</span> 1878 · Tretyakov Gallery — public domain, via Wikimedia Commons</p>
       </div>
@@ -312,7 +312,7 @@
   <footer class="on-ink grain" style="border-radius:var(--r-lg) var(--r-lg) 0 0;margin-top:var(--section-y)">
     <div style="max-width:var(--page-max);margin:0 auto;padding:72px var(--gutter) 44px;text-align:center">
       <x-import component-from-global-scope="DesignSystem_ee75f1.Kicker" hint-size="auto,18px">Liebin · 列宾</x-import>
-      <p style="font-family:var(--font-serif);font-style:italic;font-size:var(--fs-quote);line-height:var(--lh-quote);margin:16px auto 0;max-width:22ch;text-wrap:balance">你吐槽出来的那句原话，才是真正的<em style="font-weight:700">设计约束</em>。</p>
+      <p style="font-family:var(--font-serif);font-style:italic;font-size:var(--fs-quote);line-height:var(--lh-quote);margin:16px auto 0;max-width:22ch;text-wrap:balance">优秀的艺术家模仿，伟大的艺术家偷窃。</p>
       <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,220px),1fr));gap:16px;max-width:860px;margin:44px auto 0">
         <x-import component-from-global-scope="DesignSystem_ee75f1.ContactTile" icon="lucide:users" label="社区 Community" value="草诀歌 AI Labs" href="https://www.caojuege.com" target="_blank" rel="noopener" hint-size="100%,130px"></x-import>
         <x-import component-from-global-scope="DesignSystem_ee75f1.ContactTile" icon="lucide:user-round" label="关于开发者 About" value="韶华David" href="https://www.caojuege.com/davidli" target="_blank" rel="noopener" hint-size="100%,130px"></x-import>


### PR DESCRIPTION
## What changed
- Moved the hero self-portrait 28px left to tighten the visual relationship with the lead content.
- Updated the footer quote to “优秀的艺术家模仿，伟大的艺术家偷窃。”

## Validation
- Verified the requested copy and offset in `site/index.html`.
- Ran `git diff --check`.